### PR TITLE
--limit option added

### DIFF
--- a/multiddos.sh
+++ b/multiddos.sh
@@ -104,7 +104,6 @@ pip install --upgrade pip
 cat > auto_bash.sh << 'EOF'
 cd ~/multidd/
 git clone https://github.com/porthole-ascend-cinnamon/mhddos_proxy.git
-git clone https://github.com/G3nko0/traffic_proc_killer.git
 cd mhddos_proxy
 python3 -m pip install -r requirements.txt
 git clone https://github.com/MHProDev/MHDDoS.git

--- a/multiddos.sh
+++ b/multiddos.sh
@@ -111,10 +111,10 @@ git clone https://github.com/MHProDev/MHDDoS.git
 # Restart attacks and update targets every 30 minutes
 while true; do
     pkill -f start.py; pkill -f runner.py
-    if [ $limit > 0 ]; then
+    if [ $limit -gt 0 ]; then
         current_total=$(vnstat --json y | python3 -c "import sys, json; print(sum([ifc['traffic']['total']['tx']+ifc['traffic']['total']['rx'] for ifc in json.load(sys.stdin)['interfaces']]))")
         echo "Limit is set to ${limit}, current total ${current_total}"
-        if [ $current_total > $limit ]; then
+        if [ $current_total -gt $limit ]; then
             echo "Finish loop: traffic ${total} has reached the ${limit}"
             tmux kill-session -t multiddos; sudo pkill node; sudo pkill shield
             break


### PR DESCRIPTION
--limit is 0 by default and ignored, should be set in bytes. Uses vnstat yearly total from all interfaces and if it exceeds the limit terminates auto_mhddos loop and kills current tmux session, kills shield and node processes